### PR TITLE
Publish to pypi on tagging a release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Python packaging for pip
+
+on:
+  pull_request:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package for GitHub releases
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      if: ${{ startsWith(github.ref, 'refs/tags') }}
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-grade-fetcher',
-    version='0.1',
+    version='0.2',
     description='Grade Fetcher',
     license='AGPL v3',
     packages=[


### PR DESCRIPTION
see: https://appsembler.atlassian.net/wiki/spaces/ED/pages/2119237766/Setup+PyPI+publishing+workflow+via+GitHub+Actions

Blocked by:

 - #4 

### TODO
 - [x] Blocked by: #4 , get the other PR merged
 - [ ] Add pypi shared py token
 - [x] Release v0.2
 - [ ] Add `xblock-grade-fetcher` API key