### PR TITLE
breaking: cleaner pip name `xblock-grade-fetcher`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, roots):
 
 
 setup(
-    name='gradefetcher-xblock',
+    name='xblock-grade-fetcher',
     version='0.1',
     description='Grade Fetcher',
     license='AGPL v3',


### PR DESCRIPTION
this breaks the installation and requires manual changes in production servers:

```
$ ssh staging-tahoe-us-juniper-edxapp-0
$ sudo -Hsu edxapp
$ source edxapp_env
$ pip uninstall gradefetcher-xblock
$ pip install 'git+https://github.com/appsembler/xblock-grade-fetcher.git@v0.1#egg=xblock-grade-fetcher'
```
