### PR TITLE
Feat/support multiple auth endpoints

### DIFF
--- a/gradefetcher/gradefetcher.py
+++ b/gradefetcher/gradefetcher.py
@@ -35,7 +35,6 @@ class GradeFetcherXBlock(XBlock, StudioEditableXBlockMixin):
         "authentication_endpoint_password",
         "api_key",
         "grader_endpoint",
-        "http_method",
         "activity_identifier",
         "activity_identifier_parameter",
         "extra_params",

--- a/gradefetcher/gradefetcher.py
+++ b/gradefetcher/gradefetcher.py
@@ -223,11 +223,12 @@ class GradeFetcherXBlock(XBlock, StudioEditableXBlockMixin):
         # Build a list of all the fields that can be edited:
         for field_name in self.editable_fields:
             field = self.fields[field_name]
-            assert field.scope in (Scope.content, Scope.settings), (
-                "Only Scope.content or Scope.settings fields can be used with "
-                "StudioEditableXBlockMixin. Other scopes are for user-specific data and are "
-                "not generally created/configured by content authors in Studio."
-            )
+            if field.scope not in (Scope.content, Scope.settings):
+                raise ValueError(
+                    "Only Scope.content or Scope.settings fields can be used with "
+                    "StudioEditableXBlockMixin. Other scopes are for user-specific data and are "
+                    "not generally created/configured by content authors in Studio."
+                )
             field_info = self._make_field_info(field_name, field)
             if field_info is not None:
                 context["fields"].append(field_info)

--- a/gradefetcher/static/html/studio_edit.html
+++ b/gradefetcher/static/html/studio_edit.html
@@ -1,5 +1,7 @@
 {% load i18n %}
 <div class="editor-with-buttons">
+  <p style="font-weight: 600;color: red;margin: 15px 30px;">When you export this course, the Grade Fetcher Auth endpoint credentials and API Key will be exported as plaintext. Make
+  sure to keep the exported file safe!</p>
   <div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
     <ul class="list-input settings-list">
       {% for field in fields %}

--- a/gradefetcher/static/html/studio_edit.html
+++ b/gradefetcher/static/html/studio_edit.html
@@ -1,0 +1,127 @@
+{% load i18n %}
+<div class="editor-with-buttons">
+  <div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
+    <ul class="list-input settings-list">
+      {% for field in fields %}
+        <li
+          class="field comp-setting-entry metadata_entry {% if field.is_set %}is-set{% endif %}"
+          data-field-name="{{field.name}}"
+          data-default="{% if field.type == 'boolean' %}{{ field.default|yesno:'1,0' }}{% else %}{{ field.default|default_if_none:"" }}{% endif %}"
+          data-cast="{{field.type}}"
+        >
+          <div class="wrapper-comp-setting{% if field.type == "set" %} metadata-list-enum {%endif%}">
+            <label class="label setting-label" for="xb-field-edit-{{field.name}}">{{field.display_name}}</label>
+
+            {% if field.type == "boolean" %}
+              <select
+                class="field-data-control"
+                id="xb-field-edit-{{field.name}}"
+              >
+                <option value="1" {% if field.value %}selected{% endif %}>
+                  True {% if field.default %}&nbsp;&nbsp;&nbsp;&nbsp;(Default){% endif %}
+                </option>
+                <option value="0" {% if not field.value %}selected{% endif %}>
+                  False {% if not field.default %}&nbsp;&nbsp;&nbsp;&nbsp;(Default){% endif %}
+                </option>
+              </select>
+            {% elif field.has_values %}
+              <select
+                class="field-data-control"
+                id="xb-field-edit-{{field.name}}"
+              >
+                {% for option in field.values %}
+                  <option value="{{option.value}}" {% if field.value == option.value %}selected{% endif %}>
+                    {{option.display_name}} {% if option.value == field.default %}&nbsp;&nbsp;&nbsp;&nbsp;(Default){% endif %}
+                  </option>
+                {% endfor %}
+              </select>
+              {% elif field.type == "string" and field.name == "authentication_endpoint_password" %}
+                <input 
+                  type="password" 
+                  class="field-data-control" 
+                  id="xb-field-edit-{{field.name}}"
+                  value="{{field.value|default_if_none:""}}"
+                >
+            {% elif field.type == "string" and field.name == "api_key" %}
+              <input 
+                type="password" 
+                class="field-data-control" 
+                id="xb-field-edit-{{field.name}}"
+                value="{{field.value|default_if_none:""}}"
+              >
+            {% elif field.type == "string" or field.type == "datepicker" %}
+              <input
+                type="text"
+                class="field-data-control"
+                id="xb-field-edit-{{field.name}}"
+                value="{{field.value|default_if_none:""}}"
+              >
+            {% elif field.type == "integer" or field.type == "float" %}
+              <input
+                type="number"
+                class="field-data-control"
+                id="xb-field-edit-{{field.name}}"
+                {% if field.step %} step="{{field.step}}" {% elif field.type == "integer" %} step=1 {% endif %}
+                {% if field.max %} max="{{field.max}}" {% endif %}
+                {% if field.min %} min="{{field.min}}" {% endif %}
+                value="{{field.value|default_if_none:""}}"
+              >
+            {% elif field.type == "text" or field.type == "html" %}
+              <textarea class="field-data-control" data-field-name="{{field.name}}" id="xb-field-edit-{{field.name}}" rows=10 cols=70>{{field.value}}</textarea>
+            {% elif field.type == 'set' and field.has_list_values %}
+              {% comment %}
+                TODO: If len(list_values) is high, show an alternate editor 
+                with a select box and a growing list of selected choices
+              {% endcomment %}
+              <div class="wrapper-list-settings">
+                <ul class="list-settings list-set">
+                  {% for choice in field.list_values %}
+                    <li class="list-settings-item">
+                      <input
+                        id="xb-field-edit-{{field.name}}-{{forloop.counter}}"
+                        type="checkbox"
+                        value="{{choice.value}}"
+                        style="width:auto;min-width:auto;height:auto;float:left;margin-top:3px;"
+                        {% if choice.value in field.value %}checked="checked"{% endif %}
+                      >
+                      <label for="xb-field-edit-{{field.name}}-{{forloop.counter}}" style="display:block;margin-left:1.1em;">
+                        {{choice.display_name}}
+                      </label>
+                    </li>
+                  {% empty %}
+                    <li>{% trans "None Available" %}</li>
+                  {% endfor %}
+                </ul>
+              </div>
+            {% elif field.type == 'generic' or field.type == 'list' or field.type == 'set' %}
+              {# Show a textarea so we can edit it as a JSON string #}
+              <textarea class="field-data-control" data-field-name="{{field.name}}" id="xb-field-edit-{{field.name}}" rows=5 cols=70>{{field.value}}</textarea>
+            {% else %}
+              Unsupported field type. This setting cannot be edited.
+            {% endif %}
+
+            {% if field.allow_reset %}
+              <button class="action setting-clear {% if field.is_set %}active{%else%}inactive{% endif %}" type="button" name="setting-clear" value="{% trans "Clear" %}" data-tooltip="{% trans "Clear" %}">
+                <i class="icon fa fa-undo"></i><span class="sr">{% trans "Clear Value" %}</span>
+              </button>
+            {% endif %}
+          </div>
+          {% if field.help %}
+            <span class="tip setting-help"> {{ field.help|safe }} </span>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div class="xblock-actions">
+    <ul>
+      <li class="action-item">
+        <a href="#" class="button action-primary save-button">{% trans "Save" %}</a>
+      </li>
+
+      <li class="action-item">
+        <a href="#" class="button cancel-button">{% trans "Cancel" %}</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/gradefetcher/static/js/src/studio_edit.js
+++ b/gradefetcher/static/js/src/studio_edit.js
@@ -1,0 +1,196 @@
+/* Javascript for StudioEditableXBlockMixin. */
+function StudioEditableXBlockMixin(runtime, element) {
+  "use strict";
+
+  var fields = [];
+  var tinyMceAvailable = typeof $.fn.tinymce !== "undefined"; // Studio includes a copy of tinyMCE and its jQuery plugin
+  var datepickerAvailable = typeof $.fn.datepicker !== "undefined"; // Studio includes datepicker jQuery plugin
+
+  $(element)
+    .find(".field-data-control")
+    .each(function () {
+      var $field = $(this);
+      var $wrapper = $field.closest("li");
+      var $resetButton = $wrapper.find("button.setting-clear");
+      var type = $wrapper.data("cast");
+      fields.push({
+        name: $wrapper.data("field-name"),
+        isSet: function () {
+          return $wrapper.hasClass("is-set");
+        },
+        hasEditor: function () {
+          return tinyMceAvailable && $field.tinymce();
+        },
+        val: function () {
+          var val = $field.val();
+          // Cast values to the appropriate type so that we send nice clean JSON over the wire:
+          if (type == "boolean") return val == "true" || val == "1";
+          if (type == "integer") return parseInt(val, 10);
+          if (type == "float") return parseFloat(val);
+          if (type == "generic" || type == "list" || type == "set") {
+            val = val.trim();
+            if (val === "") val = null;
+            else val = JSON.parse(val); // TODO: handle parse errors
+          }
+          return val;
+        },
+        removeEditor: function () {
+          $field.tinymce().remove();
+        },
+      });
+      var fieldChanged = function () {
+        // Field value has been modified:
+        $wrapper.addClass("is-set");
+        $resetButton.removeClass("inactive").addClass("active");
+      };
+      $field.bind("change input paste", fieldChanged);
+      $resetButton.click(function () {
+        $field.val($wrapper.attr("data-default")); // Use attr instead of data to force treating the default value as a string
+        $wrapper.removeClass("is-set");
+        $resetButton.removeClass("active").addClass("inactive");
+      });
+      if (type == "html" && tinyMceAvailable) {
+        tinyMCE.baseURL = baseUrl + "/js/vendor/tinymce/js/tinymce";
+        $field.tinymce({
+          theme: "modern",
+          skin: "studio-tmce4",
+          height: "200px",
+          formats: { code: { inline: "code" } },
+          codemirror: { path: "" + baseUrl + "/js/vendor" },
+          convert_urls: false,
+          plugins: "link codemirror",
+          menubar: false,
+          statusbar: false,
+          toolbar_items_size: "small",
+          toolbar:
+            "formatselect | styleselect | bold italic underline forecolor wrapAsCode | bullist numlist outdent indent blockquote | link unlink | code",
+          resize: "both",
+          setup: function (ed) {
+            ed.on("change", fieldChanged);
+          },
+        });
+      }
+
+      if (type == "datepicker" && datepickerAvailable) {
+        $field.datepicker("destroy");
+        $field.datepicker({ dateFormat: "m/d/yy" });
+      }
+    });
+
+  $(element)
+    .find(".wrapper-list-settings .list-set")
+    .each(function () {
+      var $optionList = $(this);
+      var $checkboxes = $(this).find("input");
+      var $wrapper = $optionList.closest("li");
+      var $resetButton = $wrapper.find("button.setting-clear");
+
+      fields.push({
+        name: $wrapper.data("field-name"),
+        isSet: function () {
+          return $wrapper.hasClass("is-set");
+        },
+        hasEditor: function () {
+          return false;
+        },
+        val: function () {
+          var val = [];
+          $checkboxes.each(function () {
+            if ($(this).is(":checked")) {
+              val.push(JSON.parse($(this).val()));
+            }
+          });
+          return val;
+        },
+      });
+      var fieldChanged = function () {
+        // Field value has been modified:
+        $wrapper.addClass("is-set");
+        $resetButton.removeClass("inactive").addClass("active");
+      };
+      $checkboxes.bind("change input", fieldChanged);
+
+      $resetButton.click(function () {
+        var defaults = JSON.parse($wrapper.attr("data-default"));
+        $checkboxes.each(function () {
+          var val = JSON.parse($(this).val());
+          $(this).prop("checked", defaults.indexOf(val) > -1);
+        });
+        $wrapper.removeClass("is-set");
+        $resetButton.removeClass("active").addClass("inactive");
+      });
+    });
+
+  var studio_submit = function (data) {
+    var handlerUrl = runtime.handlerUrl(element, "submit_studio_edits");
+    runtime.notify("save", { state: "start", message: gettext("Saving") });
+    $.ajax({
+      type: "POST",
+      url: handlerUrl,
+      data: JSON.stringify(data),
+      dataType: "json",
+      global: false, // Disable Studio's error handling that conflicts with studio's notify('save') and notify('cancel') :-/
+      success: function (response) {
+        runtime.notify("save", { state: "end" });
+      },
+    }).fail(function (jqXHR) {
+      var message = gettext(
+        "This may be happening because of an error with our server or your internet connection. Try refreshing the page or making sure you are online."
+      );
+      if (jqXHR.responseText) {
+        // Is there a more specific error message we can show?
+        try {
+          message = JSON.parse(jqXHR.responseText).error;
+          if (typeof message === "object" && message.messages) {
+            // e.g. {"error": {"messages": [{"text": "Unknown user 'bob'!", "type": "error"}, ...]}} etc.
+            message = $.map(message.messages, function (msg) {
+              return msg.text;
+            }).join(", ");
+          }
+        } catch (error) {
+          message = jqXHR.responseText.substr(0, 300);
+        }
+      }
+      runtime.notify("error", {
+        title: gettext("Unable to update settings"),
+        message: message,
+      });
+    });
+  };
+
+  $(".save-button", element).bind("click", function (e) {
+    e.preventDefault();
+    var values = {};
+    var notSet = []; // List of field names that should be set to default values
+    for (var i in fields) {
+      var field = fields[i];
+      if (field.isSet()) {
+        values[field.name] = field.val();
+      } else {
+        notSet.push(field.name);
+      }
+      // Remove TinyMCE instances to make sure jQuery does not try to access stale instances
+      // when loading editor for another block:
+      if (field.hasEditor()) {
+        field.removeEditor();
+      }
+    }
+    studio_submit({ values: values, defaults: notSet });
+  });
+
+  $(element)
+    .find(".cancel-button")
+    .bind("click", function (e) {
+      // Remove TinyMCE instances to make sure jQuery does not try to access stale instances
+      // when loading editor for another block:
+      for (var i in fields) {
+        var field = fields[i];
+        if (field.hasEditor()) {
+          field.removeEditor();
+        }
+      }
+      e.preventDefault();
+      runtime.notify("cancel", {});
+    });
+}
+


### PR DESCRIPTION
DHIS2 asked us to support multiple authentication endpoint since they want to fetch grades from multiple systems, and they can have different authentication endpoint and credentials.
In the PR, we extracted Auth endpoint credentials and API_KEY from the site settings and moved it to the XBlock Author View, so the site admin can set up the auth endpoint settings in studio, and it doesn't require someone from our end to make that change in site settings.

![Screen Shot 2022-03-02 at 18 32 07](https://user-images.githubusercontent.com/5863396/156467374-8b8ee90f-d00d-48e2-8e5e-2c07f082c8f7.png)


