### PR TITLE
chore: adding pre-commit to run flake8 before pushing to remote

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,12 @@ repos:
     rev: 1.7.4
     hooks:
       - id: bandit
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
+  - repo: https://github.com/psf/black
+    rev: 22.1.0
+    hooks:
+      - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,14 @@
 repos:
--   repo: https://gitlab.com/PyCQA/flake8
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: requirements-txt-fixer
+      - id: end-of-file-fixer
+  - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
-    -   id: flake8
+      - id: flake8
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.4
+    hooks:
+      - id: bandit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://gitlab.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+    -   id: flake8


### PR DESCRIPTION
I created this PR to run flake8 before we commit changes in the repo. It frequently happened to me that I made changes in the repo and pushed to the remote, and it doesn't pass our CI pipeline and I have to spend some time to fix the issues and commit again.
To make this work we need to run `pip install pre-commit` and every time someone commits something flake8 run and checks the files.
I think we can include `isort` and `bandit` too