### PR TITLE
chore: raise timeout for grader call and use requests params

### DIFF
--- a/gradefetcher/gradefetcher.py
+++ b/gradefetcher/gradefetcher.py
@@ -384,12 +384,12 @@ class GradeFetcherXBlock(XBlock, StudioEditableXBlockMixin):
                         ] = self.activity_identifier
                     if self.extra_params:
                         query.update(urllib.parse.parse_qs(self.extra_params))
-                    str_query = urllib.parse.urlencode(query)
                     grader_response = requests.get(
-                        self.grader_endpoint + str_query,
+                        self.grader_endpoint,
+                        params=query,
                         proxies=proxies,
                         headers=grader_headers,
-                        timeout=10,
+                        timeout=15,
                     )
                     grades = []
                     if "results" not in grader_response.json():


### PR DESCRIPTION
- Grader endpoint can take longer than 10 seconds to respond with grad result, raised the timeout to 15 seconds
- Using requests parameters instead of urllib query parsing